### PR TITLE
[WIP] Add Swipe support between navbar pages

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -399,7 +399,7 @@ class FeedTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      height: 300,
+      height: 400,
       margin: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8),
       color: Theme.of(context).colorScheme.surface,
       child: Card(
@@ -517,6 +517,8 @@ class _ProductListState extends ConsumerState<ProductList> {
         title: const Text('Products'),
       ),
       body: ListView.builder(
+          scrollDirection: Axis.horizontal,
+          itemCount: 5,
           controller: _scrollController,
           itemBuilder: (context, index) {
             return Padding(
@@ -552,6 +554,7 @@ class ProductTile extends StatelessWidget {
     return Card(
       child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 12),
+          width: MediaQuery.of(context).size.width,
           height: 120,
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -521,7 +521,9 @@ class _ProductListState extends ConsumerState<ProductList> {
           itemCount: 5,
           controller: _scrollController,
           itemBuilder: (context, index) {
-            return Padding(
+            return Container(
+              height: 200,
+              color: Colors.redAccent.shade100,
               padding: const EdgeInsets.all(8.0),
               child: InkWell(
                   onTap: () {

--- a/lib/src/navbar_notifier.dart
+++ b/lib/src/navbar_notifier.dart
@@ -75,6 +75,9 @@ class NavbarNotifier extends ChangeNotifier {
     if (_navbarStackHistory.contains(x)) {
       _navbarStackHistory.remove(x);
     }
+
+    // just my suggestion
+    hideBottomNavBar = false;
     _navbarStackHistory.add(x);
     _notifyIndexChangeListeners(x);
     _singleton.notify();
@@ -108,6 +111,8 @@ class NavbarNotifier extends ChangeNotifier {
       if (behavior == BackButtonBehavior.rememberHistory) {
         if (_navbarStackHistory.length > 1) {
           _navbarStackHistory.removeLast();
+
+          // fix issue #53
           index = _navbarStackHistory.last;
           _singleton.notify();
           exitingApp = false;

--- a/lib/src/navbar_notifier.dart
+++ b/lib/src/navbar_notifier.dart
@@ -108,7 +108,7 @@ class NavbarNotifier extends ChangeNotifier {
       if (behavior == BackButtonBehavior.rememberHistory) {
         if (_navbarStackHistory.length > 1) {
           _navbarStackHistory.removeLast();
-          _index = _navbarStackHistory.last;
+          index = _navbarStackHistory.last;
           _singleton.notify();
           exitingApp = false;
         } else {

--- a/lib/src/navbar_router.dart
+++ b/lib/src/navbar_router.dart
@@ -1,7 +1,6 @@
-// ignore_for_file: public_member_api_docs, sort_constructors_first
+// ignore_for_file: public_member_api_docs, sort_constructors_first, avoid_print
 
 import 'package:badges/badges.dart' as badges;
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -221,27 +220,7 @@ class _NavbarRouterState extends State<NavbarRouter>
     initAnimation();
     NavbarNotifier.index = widget.initialIndex;
     _pageController = ScrollController();
-    _pageController.addListener(
-      () {
-        // if (!mounted) return;
-        // print(_pageController.offset);
 
-        // var page = getPageFromPixels(context);
-        // // print(page);
-        // if ((page.round() - page).abs() < 0.2 &&
-        //     page.round() != NavbarNotifier.currentIndex) {
-        //   // if ((page.round() - NavbarNotifier.currentIndex).abs() == 1) {
-        //   //   if ((page - NavbarNotifier.currentIndex).abs() > 0.3) return;
-        //   // }
-        //   int value = page.round();
-        //   NavbarNotifier.index = value;
-        //   if (widget.onChanged != null) {
-        //     widget.onChanged!(value);
-        //   }
-        //   _handleFadeAnimation();
-        // }
-      },
-    );
     NavbarNotifier.addIndexChangeListener(
       (newIndex) {
         if (!mounted) return;
@@ -415,7 +394,7 @@ class _NavbarRouterState extends State<NavbarRouter>
                           return KeepAliveWrapper(
                             child: NotificationListener<OverscrollNotification>(
                                 onNotification: (OverscrollNotification value) {
-                                  // print(value.metrics.pixels);
+                                  print(value.overscroll);
                                   if (value.overscroll < 0 &&
                                       _pageController.offset +
                                               value.overscroll <=
@@ -437,14 +416,20 @@ class _NavbarRouterState extends State<NavbarRouter>
                                     }
                                     return true;
                                   }
-                                  _pageController.jumpTo(
-                                      _pageController.offset +
-                                          value.overscroll);
+                                  if (value.overscroll.abs() < 0.1) {
+                                    _pageController.jumpTo(
+                                        _pageController.offset +
+                                            value.overscroll);
+                                  } else {
+                                    _pageController.animateTo(
+                                        getPixelsFromPage(
+                                            NavbarNotifier.currentIndex),
+                                        duration: Durations.short2,
+                                        curve: Curves.ease);
+                                  }
                                   return true;
                                 },
-                                child: Container(
-                                    // color:
-                                    //     Colors.blueAccent.withOpacity(0.5),
+                                child: SizedBox(
                                     width: MediaQuery.of(context).size.width -
                                         getPadding(),
                                     child: _buildIndexedStackItem(i, context))),
@@ -533,7 +518,7 @@ class _NavbarRouterState extends State<NavbarRouter>
                         onDragEnd(details);
                       },
                       child: Container(
-                        color: Colors.blueAccent.withOpacity(0.5),
+                        color: Colors.blueAccent.withOpacity(0.3),
                       ),
                     ),
                   )


### PR DESCRIPTION
- ## This PR supports #42 
- ## Feature:

- The two blue bars indicate the area to swipe between pages, we can only swipe to the next/previous page from there.
- The horizontal swipe does not hinder other scrollables on the screen (notice the horizontal list, and the slider)
- Video:

https://github.com/user-attachments/assets/4ed3c48e-5896-4a03-b8ff-a7500e40db47




- ## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing using `flutter test`

If you need help, consider pinging the maintainer @maheshmnj

<!-- Links -->
[Contributor Guide]: https://github.com/maheshmnj/searchfield/blob/master/CONTRIBUTING.md